### PR TITLE
Port CRC Cpp to Conan v2

### DIFF
--- a/recipes/crc_cpp/all/conanfile.py
+++ b/recipes/crc_cpp/all/conanfile.py
@@ -1,55 +1,60 @@
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import get
+from conan.tools.files import get, copy
 from conan.tools.scm import Version
+from conan.tools.layout import basic_layout
 from conan.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.50.0"
+
+required_conan_version = ">=1.54.0"
 
 
 class Crc_CppConan(ConanFile):
     name = "crc_cpp"
     description = "A header only constexpr / compile time small-table based CRC library for C++17 and newer"
-    topics = "crc_cpp", "crc", "constexpr", "cpp17", "cpp20", "header-only"
-    settings = "compiler", "os"
+    topics = ("crc", "constexpr", "cpp17", "cpp20", "header-only")
+    settings = "os", "arch", "compiler", "build_type"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/AshleyRoll/crc_cpp"
     license = "MIT"
+    package_type = "header-library"
     no_copy_source = True
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def _min_cppstd(self):
+        return 17
 
     @property
-    def _supported_compiler(self):
-        compiler = str(self.settings.compiler)
-        version = Version(self.settings.compiler.version)
-        if compiler == "Visual Studio" and version >= "15":
-            return True
-        elif compiler == "gcc" and version >= "9":
-            return True
-        elif compiler == "clang" and version >= "5":
-            return True
-        elif compiler == "apple-clang" and version >= "10":
-            return True
-        else:
-            self.output.warn("{} recipe lacks information about the {} compiler standard version support".format(self.name, compiler))
-        return False
+    def _compilers_minimum_version(self):
+        return {
+            "Visual Studio": "15",
+            "msvc": "14.1",
+            "gcc": "9",
+            "clang": "5",
+            "apple-clang": "10",
+        }
 
-    def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, "17")
-        if not self._supported_compiler:
-            raise ConanInvalidConfiguration("crc_cpp: Unsupported compiler: {}-{} "
-                                            "Minimum C++17 constexpr features required.".format(self.settings.compiler, self.settings.compiler.version))
-    def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
-
-    def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy(pattern="*", dst="include", src=os.path.join(self._source_subfolder, "include"))
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def package_id(self):
         self.info.clear()
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.")
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self, pattern="*", dst=os.path.join(self.package_folder, "include"), src=os.path.join(self.source_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/crc_cpp/all/test_package/CMakeLists.txt
+++ b/recipes/crc_cpp/all/test_package/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(crc_cpp REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} PRIVATE crc_cpp::crc_cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/crc_cpp/all/test_package/conanfile.py
+++ b/recipes/crc_cpp/all/test_package/conanfile.py
@@ -1,11 +1,19 @@
-from conan import ConanFile, tools
-from conans import CMake
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -13,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.build.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/crc_cpp/all/test_v1_package/CMakeLists.txt
+++ b/recipes/crc_cpp/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/crc_cpp/all/test_v1_package/conanfile.py
+++ b/recipes/crc_cpp/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.build.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **crc_cpp/1.2.0**

There are several considerations when porting a recipe to Conan 2.x, including:

- Add test_v1_package to validate Conan 1.x support
- Update test package to run with Conan 2.x
- Replace old tools like self.copy by copy(self,...)
- Consider package-type to improve not package ID, but visibility
- Use folder layout to keep simpler way of copying files
- Set cpp_info to avoid folder creation when not using them with header-only projects
- Improve compiler check based on msvc and others.


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
